### PR TITLE
syscarlist.cgi Retrieve min/max values only when sysvar is numeric

### DIFF
--- a/xmlapi/sysvarlist.cgi
+++ b/xmlapi/sysvarlist.cgi
@@ -49,8 +49,14 @@ append hm_script {;
                 if (sShowText == "true") {
                         Write("' value_text='"); WriteXML( oSysVar.ValueList().StrValueByIndex(';', oSysVar.Value()));
                 }
-                Write("' min='"); WriteXML( oSysVar.ValueMin());
-                Write("' max='"); WriteXML( oSysVar.ValueMax());
+                Write("' min='");
+                if (oSysVar.ValueType() == 4) {
+                    WriteXML( oSysVar.ValueMin());
+                }
+                Write("' max='");
+                if (oSysVar.ValueType() == 4) {
+                    WriteXML( oSysVar.ValueMax());
+                }
                 Write("' unit='"); WriteXML( oSysVar.ValueUnit());
                 Write("' type='"); WriteXML( oSysVar.ValueType());
                 Write("' subtype='"); WriteXML( oSysVar.ValueSubType());


### PR DESCRIPTION
min and max values are only requested if ValueType = 4 (numeric). This prevents Rega Log Entries "metadata property 'MIN' does not exist" and "metadata property 'MAX' does not exist" for every nonnumeric sysvar every time sysvarlist.cgi is called.

Fixes Issue #45 